### PR TITLE
Readme links to Actively Maintained Browsermob Proxy Alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ See also
 * http://bmp.lightbody.net/
 * https://github.com/lightbody/browsermob-proxy
 
-
 Note on Patches/Pull Requests
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ support, and more. It is an API compatible drop-in replacement, so using it is j
 
 The only compatibility exception is the deprecated legacy API.
 
-This release should work with the binar for either the BrowserUp Proxy, or the BrowserMob Proxy.
+This release should work with the binary for either the BrowserUp Proxy, or the BrowserMob Proxy.
 
 How to use with selenium-webdriver
 ----------------------------------

--- a/README.md
+++ b/README.md
@@ -3,8 +3,15 @@ browsermob-proxy-rb
 
 Ruby client for the BrowserMob Proxy 2.0 REST API.
 
-[![Build Status](https://secure.travis-ci.org/jarib/browsermob-proxy-rb.png)](http://travis-ci.org/jarib/browsermob-proxy-rb)
+NOTE: The BrowserMob Proxy is no longer actively maintained and has had no releases since 2016. 
 
+A [BrowserMob Proxy alternative](http://browserup.com/blog/announcement-an-actively-maintained-fork-of-the-browsermob-proxy/) is now
+available in the BrowserUp Proxy. The BrowserUp Proxy is an actively maintained fork of the BrowserMob proxy. It has added HTTP/2, Java 11, Brotli compression
+support, and more. It is an API compatible drop-in replacement, so using it is just a matter of using the BrowserUp proxy binary instead.
+
+The only compatibility exception is the deprecated legacy API.
+
+This release should work with the binar for either the BrowserUp Proxy, or the BrowserMob Proxy.
 
 How to use with selenium-webdriver
 ----------------------------------
@@ -64,9 +71,11 @@ The HAR gem includes a HAR viewer. After running the code above, you can view th
 
 See also
 --------
+* https://github.com/browserup/browserup-proxy
 
 * http://bmp.lightbody.net/
 * https://github.com/lightbody/browsermob-proxy
+
 
 Note on Patches/Pull Requests
 -----------------------------
@@ -82,7 +91,8 @@ Note on Patches/Pull Requests
 Copyright
 ---------
 
-Copyright 2011-2014 Jari Bakken
+Copyright 2011-2019 Jari Bakken
+Copyright 2019 Eric Beland
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/browsermob-proxy.gemspec
+++ b/browsermob-proxy.gemspec
@@ -6,11 +6,11 @@ Gem::Specification.new do |s|
   s.name        = "browsermob-proxy"
   s.version     = BrowserMob::Proxy::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["jari.bakken"]
-  s.email       = ["jari.bakken@gmail.com"]
-  s.homepage    = "http://github.com/jarib/browsermob-proxy-rb"
-  s.summary     = %q{Ruby client for the BrowserMob Proxy REST API}
-  s.description = %q{Ruby client for the BrowserMob Proxy REST API}
+  s.authors     = ["Eric Beland"]
+  s.email       = ["ebeland@browserup.com"]
+  s.homepage    = "http://github.com/browserup/browsermob-proxy-rb"
+  s.summary     = %q{Ruby client for the BrowserMob and BrowserUp Proxy REST API}
+  s.description = %q{Ruby client for the BrowserMob and BrowserUp Proxy REST API}
   s.license     = 'Apache'
 
   s.rubyforge_project = "browsermob-proxy-rb"

--- a/lib/browsermob/proxy/version.rb
+++ b/lib/browsermob/proxy/version.rb
@@ -1,5 +1,5 @@
 module BrowserMob
   module Proxy
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
This PR updates the Readme to include a link to the BrowserUp Proxy. The BrowserUp proxy is a fork of the BrowserMob Proxy with active maintainers and added HTTP/2, Brotli Compression, Java 11 support and security fixes. The original BrowserMob proxy is bit-rotting. It hasn't had a release since 2016 and the maintainers are inactive.

The BrowserUp proxy is a drop-in replacement for the BrowserMob Proxy. 